### PR TITLE
DRYD-1213,DRYD-1214: Add description level and apparel size fields

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -153,6 +153,10 @@ const template = (configContext) => {
             <Field name="colors">
               <Field name="color" />
             </Field>
+
+            <Field name="apparelSizes">
+              <Field name="apparelSize" />
+            </Field>
           </Col>
         </Row>
 

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -48,6 +48,7 @@ const template = (configContext) => {
               </Col>
             </Row>
 
+            <Field name="descriptionLevel" />
             <Field name="recordStatus" />
 
             <Field name="publishToList">


### PR DESCRIPTION
**What does this do?**
* Adds apparel size and descriptionLevel to default collectionobject form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1214

This is a field which existed in the OHC profile was was requested to be brought into lhmc

**How should this be tested? Do these changes have associated tests?**
* Rebuild and run collectionspace
* Bring in the latest changes from cspace-ui.js into your `node_modules`
* Run the devserver
* Create a collectionobject with an apparel size(s)
* Reload the collectionobject to ensure the save completed successfully

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter built and tested the new field saves