### PR TITLE
Use default CS messages for movement procedure fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v6.1.0
+
+Message overrides for fields in the Location/Movement/Inventory procedure inherited from core are removed.
+
+The message for the LHMC-specific tempLocAuthorizedBy field is changed from "Temp location authorized by" to "Location authorized by".
+
 ## v6.0.0
 
 v6.0.0 adds support for CollectionSpace 7.2.

--- a/src/messages.js
+++ b/src/messages.js
@@ -46,24 +46,6 @@ export default {
   'field.intakes_common.conditionCheckerOrAssessor.fullName': 'Condition check by',
   'field.intakes_common.conditionCheckerOrAssessor.name': 'Condition by',
 
-  // movement
-
-  'field.movements_common.movementReferenceNumber.name': 'Object ID',
-  'field.movements_common.normalLocation.name': 'Home location/building',
-  'inputTable.movement.currentLocation': 'Temp location/building',
-  'field.movements_common.currentLocation.fullName': 'Temp location/building',
-  'field.movements_common.currentLocation.name': 'Location/building',
-  'field.movements_common.currentLocationFitness.fullName': 'Temp location/building fitness',
-  'field.movements_common.currentLocationNote.fullName': 'Temp location/building note',
-  'field.movements_common.locationDate.name': 'Inventoried date',
-  'field.movements_common.reasonForMove.name': 'Reason',
-  'field.movements_common.movementContact.fullName': 'Moved by',
-  'field.movements_common.movementContact.name': 'Moved by',
-  'field.movements_common.plannedRemovalDate.name': 'Temp location until',
-  'field.movements_common.removalDate.name': 'Temp location date',
-  'field.movements_common.movementNote.fullName': 'Temp location note',
-  'field.movements_common.movementNote.name': 'Temp location note',
-
   // person
 
   'field.persons_common.personTermGroupList.required': 'At least one full name is required. Please enter a value.',

--- a/src/plugins/recordTypes/movement/fields.js
+++ b/src/plugins/recordTypes/movement/fields.js
@@ -22,7 +22,7 @@ export default (configContext) => {
             messages: defineMessages({
               name: {
                 id: 'field.movements_lhmc.tempLocAuthorizedBy.name',
-                defaultMessage: 'Temp location authorized by',
+                defaultMessage: 'Location authorized by',
               },
             }),
             view: {


### PR DESCRIPTION
**What does this do?**
Removes message overrides for movement procedure fields defined in core. Updates the label for the one movement procedure defined in this plugin.

**Why are we doing this? (with JIRA link)**
I don't think Jessi made a JIRA for this one. This changes makes the LHMC movement procedure consistent with other profiles and was approved by the one user we know to currently be using LHMC. 

**How should this be tested? Do these changes have associated tests?**
Compare the LHMC movement procedure to the Core movement procedure. The labels should match. The `tempLocAuthorizedBy` field label should be "Location authorized by".

**Dependencies for merging? Releasing to production?**
Don't think so.

**Has the application documentation been updated for these changes?**
Not needed? 

**Did someone actually run this code to verify it works?**
I ran it using lhmc.dev as the server URL and everything looked good. 