### PR TITLE
Update Layouts For Multiline Notes

### DIFF
--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -71,11 +71,15 @@ const template = (configContext) => {
 
         <Field name="approvalGroupList">
           <Field name="approvalGroup">
-            <Field name="approvalGroup" />
-            <Field name="approvalIndividual" />
-            <Field name="approvalStatus" />
-            <Field name="approvalDate" />
-            <Field name="approvalNote" />
+            <Panel>
+              <Row>
+                <Field name="approvalGroup" />
+                <Field name="approvalIndividual" />
+                <Field name="approvalStatus" />
+                <Field name="approvalDate" />
+              </Row>
+              <Field name="approvalNote" />
+            </Panel>
           </Field>
         </Field>
         <Field name="acquisitionNote" />

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -77,10 +77,14 @@ const template = (configContext) => {
 
         <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
           <Field name="annotationGroup">
-            <Field name="annotationType" />
-            <Field name="annotationNote" />
-            <Field name="annotationDate" />
-            <Field name="annotationAuthor" />
+            <Panel>
+              <Row>
+                <Field name="annotationType" />
+                <Field name="annotationDate" />
+                <Field name="annotationAuthor" />
+              </Row>
+              <Field name="annotationNote" />
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/intake/forms/default.jsx
+++ b/src/plugins/recordTypes/intake/forms/default.jsx
@@ -49,11 +49,15 @@ const template = (configContext) => {
 
         <Field name="approvalGroupList">
           <Field name="approvalGroup">
-            <Field name="approvalGroup" />
-            <Field name="approvalIndividual" />
-            <Field name="approvalStatus" />
-            <Field name="approvalDate" />
-            <Field name="approvalNote" />
+            <Panel>
+              <Row>
+                <Field name="approvalGroup" />
+                <Field name="approvalIndividual" />
+                <Field name="approvalStatus" />
+                <Field name="approvalDate" />
+              </Row>
+              <Field name="approvalNote" />
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/loanin/fields.js
+++ b/src/plugins/recordTypes/loanin/fields.js
@@ -54,9 +54,6 @@ export default (configContext) => {
               repeating: true,
               view: {
                 type: CompoundInput,
-                props: {
-                  tabular: true,
-                },
               },
             },
             loaninStatusLHMC: {
@@ -111,6 +108,9 @@ export default (configContext) => {
                 }),
                 view: {
                   type: TextInput,
+                  props: {
+                    multiline: true,
+                  },
                 },
               },
             },

--- a/src/plugins/recordTypes/loanin/forms/default.jsx
+++ b/src/plugins/recordTypes/loanin/forms/default.jsx
@@ -23,10 +23,14 @@ const template = (configContext) => {
 
         <Field name="loaninStatusLHMCGroupList" subpath="ns2:loansin_lhmc">
           <Field name="loaninStatusLHMCGroup">
-            <Field name="loaninStatusLHMC" />
-            <Field name="loaninStatusDateLHMC" />
-            <Field name="loaninStatusNoteLHMC" />
-            <Field name="loaninStatusAuthorizerLHMC" />
+            <Panel>
+              <Row>
+                <Field name="loaninStatusLHMC" />
+                <Field name="loaninStatusDateLHMC" />
+                <Field name="loaninStatusAuthorizerLHMC" />
+              </Row>
+              <Field name="loaninStatusNoteLHMC" />
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/loanout/fields.js
+++ b/src/plugins/recordTypes/loanout/fields.js
@@ -54,9 +54,6 @@ export default (configContext) => {
               repeating: true,
               view: {
                 type: CompoundInput,
-                props: {
-                  tabular: true,
-                },
               },
             },
             loanoutStatusLHMC: {
@@ -111,6 +108,9 @@ export default (configContext) => {
                 }),
                 view: {
                   type: TextInput,
+                  props: {
+                    multiline: true,
+                  },
                 },
               },
             },

--- a/src/plugins/recordTypes/loanout/forms/default.jsx
+++ b/src/plugins/recordTypes/loanout/forms/default.jsx
@@ -41,10 +41,14 @@ const template = (configContext) => {
 
         <Field name="loanoutStatusLHMCGroupList" subpath="ns2:loansout_lhmc">
           <Field name="loanoutStatusLHMCGroup">
-            <Field name="loanoutStatusLHMC" />
-            <Field name="loanoutStatusDateLHMC" />
-            <Field name="loanoutStatusNoteLHMC" />
-            <Field name="loanoutStatusAuthorizerLHMC" />
+            <Panel>
+              <Row>
+                <Field name="loanoutStatusLHMC" />
+                <Field name="loanoutStatusDateLHMC" />
+                <Field name="loanoutStatusAuthorizerLHMC" />
+              </Row>
+              <Field name="loanoutStatusNoteLHMC" />
+            </Panel>
           </Field>
         </Field>
 


### PR DESCRIPTION
**What does this do?**
* Update the annotation groups to allow for multiline notes
* Update the loan groups to allow for multiline notes

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1284
Jira: https://collectionspace.atlassian.net/browse/DRYD-1285

This allows the `annotationNote` to be more useful in practice as users will be able to add useful information to the field. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Go to create a new procedure (acquisition, loanin, loanout, collectionobject) with the new layout see the annotation group with multiline input for the note
* Create the new procedure with the annotation group fields filled out and verify it saves/reloads

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance