### PR TITLE
Update fieldCollectionPlace to be repeatable

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -581,7 +581,9 @@ const template = (configContext) => {
               <Field name="fieldCollectionMethod" />
             </Field>
 
-            <Field name="fieldCollectionPlace" />
+            <Field name="fieldCollectionPlaces">
+              <Field name="fieldCollectionPlace" />
+            </Field>
 
             <Field name="fieldCollectionSources">
               <Field name="fieldCollectionSource" />


### PR DESCRIPTION
**What does this do?**
Updates the collectionobject form to include fieldCollectionPlaces so that fieldCollectionPlace displays as a repeatable input.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1395

This was missed when making updates to the profiles which used fieldCollectionPlace as it is being updated to be a repeatable input.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a collectionobject
* See that the Field collection place input is repeatable, and can save/load multiple inputs

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally