### PR TITLE
DRYD-1506: Add published related links

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -570,6 +570,13 @@ const template = (configContext) => {
             <Field name="referenceNote" />
           </Field>
         </Field>
+
+        <Field name="publishedRelatedLinkGroupList">
+          <Field name="publishedRelatedLinkGroup">
+            <Field name="relatedLink" />
+            <Field name="descriptiveTitle" />
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="collect" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/photo.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/photo.jsx
@@ -255,6 +255,13 @@ const template = (configContext) => {
             <Field name="referenceNote" />
           </Field>
         </Field>
+
+        <Field name="publishedRelatedLinkGroupList">
+          <Field name="publishedRelatedLinkGroup">
+            <Field name="relatedLink" />
+            <Field name="descriptiveTitle" />
+          </Field>
+        </Field>
       </Panel>
 
       <Panel name="hierarchy" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -151,6 +151,15 @@ const template = (configContext) => {
       <Panel name="viewer" collapsible>
         <Field name="viewersContributionNote" />
       </Panel>
+
+      <Panel name="reference" collapsible collapsed>
+        <Field name="publishedRelatedLinkGroupList">
+          <Field name="publishedRelatedLinkGroup">
+            <Field name="relatedLink" />
+            <Field name="descriptiveTitle" />
+          </Field>
+        </Field>
+      </Panel>
     </Field>
   );
 };


### PR DESCRIPTION
**What does this do?**
* Add publishedRelatedLinkGroup to forms

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1506

The `publishedRelatedLinkGroupList` was added to core and is now being added to profiles which can use it.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver `npm run devserver --back-end=https://lhmc.dev.collectionspace.org`
* Create a collectionobject
* View the `Reference Information` section and see that the published links 

**Dependencies for merging? Releasing to production?**
I wasn't entirely sure of which templates to add this to for all profiles. It was added to default and public in core so I've added it to both here and the photo template which also had the reference section.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using lhmc.dev as a backend