### PR TITLE
DRYD-1319: Remove phase, sex, and form

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -143,13 +143,6 @@ const template = (configContext) => {
             <Field name="objectStatusList">
               <Field name="objectStatus" />
             </Field>
-
-            <Field name="sex" />
-            <Field name="phase" />
-
-            <Field name="forms">
-              <Field name="form" />
-            </Field>
           </Col>
 
           <Col>


### PR DESCRIPTION
**What does this do?**
* Remove phase, sex, and form from default template

**Why are we doing this? (with JIRA link)**
* Jira: https://collectionspace.atlassian.net/browse/DRYD-1319

These fields are specific to Herbarium, Bonsai, Bot Garden and Anthro and are being hidden in lhmc. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver: `npm run devserver --back-end=https://lhmc.dev.collectionspace.org`
* See that the 3 fields were removed from the template (under `Object Description Information`)

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
Noe

**Did someone actually run this code to verify it works?**
@mikejritter tested with lhmc.dev as a backend