### PR TITLE
DRYD-1503: Add production place verbatim

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -110,18 +110,18 @@ export default (configContext) => {
             ns: 'http://collectionspace.org/services/collectionobject/domain/objectprod_extension',
           },
         },
-        objectProductionLocationsVerbatim: {
+        objectProductionPlacesVerbatim: {
           [config]: {
             view: {
               type: CompoundInput,
             },
           },
-          objectProductionLocationVerbatim: {
+          objectProductionPlaceVerbatim: {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.collectionobjects_objectprod.objectProductionLocationVerbatim.name',
-                  defaultMessage: 'Production location (verbatim)',
+                  id: 'field.collectionobjects_objectprod.objectProductionPlaceVerbatim.name',
+                  defaultMessage: 'Production place (verbatim)',
                 },
               }),
               repeating: true,

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -104,6 +104,34 @@ export default (configContext) => {
           },
         },
       },
+      'ns2:collectionobjects_objectprod_extension': {
+        [config]: {
+          service: {
+            ns: 'http://collectionspace.org/services/collectionobject/domain/objectprod_extension',
+          },
+        },
+        objectProductionLocationsVerbatim: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          objectProductionLocationVerbatim: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_objectprod.objectProductionLocationVerbatim.name',
+                  defaultMessage: 'Production location (verbatim)',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: TextInput,
+              },
+            },
+          },
+        },
+      },
       ...extensions.culturalcare.collectionobject.fields,
     },
   };

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -1,8 +1,12 @@
+import { defineMessages } from 'react-intl';
+
 export default (configContext) => {
   const {
     AutocompleteInput,
+    CompoundInput,
     OptionPickerInput,
     TermPickerInput,
+    TextInput,
   } = configContext.inputComponents;
 
   const {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -355,6 +355,10 @@ const template = (configContext) => {
               </Field>
             </Field>
 
+            <Field name="objectProductionLocationsVerbatim" subpath="ns2:collectionobjects_objectprod_extension">
+              <Field name="objectProductionLocationVerbatim" />
+            </Field>
+
             <Field name="objectProductionReasons">
               <Field name="objectProductionReason" />
             </Field>

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -355,8 +355,8 @@ const template = (configContext) => {
               </Field>
             </Field>
 
-            <Field name="objectProductionLocationsVerbatim" subpath="ns2:collectionobjects_objectprod_extension">
-              <Field name="objectProductionLocationVerbatim" />
+            <Field name="objectProductionPlacesVerbatim" subpath="ns2:collectionobjects_objectprod_extension">
+              <Field name="objectProductionPlaceVerbatim" />
             </Field>
 
             <Field name="objectProductionReasons">


### PR DESCRIPTION
**What does this do?**
* Add production place verbatim field

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1503

This field was requested to be added for the 8.1 release. As it is only going in a few profiles, it is being done as an extension rather than a part of the base collectionobject.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace with the application PR
* Run `npm run lint` and `npm run test` as a sanity check
* Start the devserver: `npm run devserver`
* Create a collectionobject with the new field (production place verbatim)
 * Ensure the new field saves and loads

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested on a local instance using anthro