### PR TITLE
DRYD-1610: Disable NAGPRA Procedures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,30 @@ export default () => ({
   className: styles.common,
   prettyUrls: true,
   tenantId: '501',
+  // normally this is done in each recordType config but with so many it's a little cleaner here
+  recordTypes: {
+    consultation: {
+      disabled: true,
+    },
+    dutyofcare: {
+      disabled: true,
+    },
+    nagprainventory: {
+      disabled: true,
+    },
+    repatriationrequest: {
+      disabled: true,
+    },
+    summarydocumentation: {
+      disabled: true,
+    },
+    heldintrust: {
+      disabled: true,
+    },
+    restrictedmedia: {
+      disabled: true,
+    },
+  },
   pluginInfo: {
     cspaceUIPluginProfileLHMC: {
       messages: defineMessages({


### PR DESCRIPTION
**What does this do?**
* Disable NAGPRA Procedures

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1610

Having procedures which are enabled in config but disabled in the services layer is kind of a pain for various reasons. By disabling them we can have better consistency when using the ui or the config from other services.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver with dev as a backend
* Navigate to the config download, e.g. `http://localhost:8080/cspace/lhmc/config`
* Verify the json doesn't contain any of the nagpra procedures, e.g.
```
jq .recordTypes.consultation cspace-ui-config.json
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with dev as a backend