### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -2,9 +2,9 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   check:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,28 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Publish NPM Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  check-code:
+    name: check-code
+    uses: collectionspace/.github/.github/workflows/check-js.yml@main
+
+  publish-npm:
+    needs: check-code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: browser-actions/setup-chrome@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
**What does this do?**
* Updates the target branch for the ci workflow to main
* Adds an npm publish workflow

**Why are we doing this? (with JIRA link)**
No Jira.

The branch change is being done to align with the github workflow docs in the wiki. The publish workflow is for assisting with releasing so that we only need to create the release and not run `npm publish` manually. 

**Did someone actually run this code to verify it works?**
This was added and tested in the publicart repository 