### PR TITLE
DRYD-1779: Add technique and type to public browser template

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -125,6 +125,13 @@ const template = (configContext) => {
                 <Field name="objectProductionPlaceRole" />
               </Field>
             </Field>
+
+            <Field name="techniqueGroupList">
+              <Field name="techniqueGroup">
+                <Field name="technique" />
+                <Field name="techniqueType" />
+              </Field>
+            </Field>
           </Col>
 
           <Col>


### PR DESCRIPTION
**What does this do?**
Adds technique and technique type to the public browser template

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1779

These were missed when updating the public browser template, and need to be added because these fields are being indexed when populated.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver --back-end=https://lhmc.dev.collectionspace.org`
* Create a CollectionObject
* See `Technique` and `Type` in the `Production technique` group

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with lhmc.dev as a backend