### PR TITLE
DRYD-2009: Procedure > Acquisition > Add Parties Involved Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v8.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2
 ### Changes
 
 - Added the Acquisition description free text field (`acquisitionDescription`) to the record editor for Acquisitions.
+- Added the Parties Involved group of fields (`partiesInvolvedGroupList/partiesInvolvedGroup`) to the record editor for Acquisitions.
 
 ## V8.1.0
 

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -98,6 +98,14 @@ const template = (configContext) => {
           </Field>
         </Row>
 
+        <Field name="partiesInvolvedGroupList">
+          <Field name="partiesInvolvedGroup">
+            <Field name="involvedParty" />
+            <Field name="involvedOnBehalfOf" />
+            <Field name="involvedRole" />
+          </Field>
+        </Field>
+
         <Field name="creditLine" />
       </Panel>
 


### PR DESCRIPTION
**What does this do?**
* Add the Parties Involved group to the acquisition default form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2009

This group was added to the default cspace-ui form and was requested to be added to fcart as well.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver (once the nightly build runs, using lhmc as a backend should be an option)
* Create an acquisition with the parties involved group of fields

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The changelog was updated

**Did someone actually run this code to verify it works?**
no