### PR TITLE
DRYD-2073: Object Record > All Profiles > Add Home Location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## V8.3.0
+
+### Changes
+- Adds `homeStorageLocation` to the `default` template.
+
 ## V8.2.0
 
 v8.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## V8.3.0
 
 ### Changes
-- Adds `homeStorageLocation` to the `default` template.
+- Adds `homeLocationGroupList` to the `default` template.
 
 ## V8.2.0
 

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -71,7 +71,13 @@ const template = (configContext) => {
             </Field>
 
             <Field name="computedCurrentLocation" />
-            <Field name="homeStorageLocation" />
+
+            <Field name="homeLocationGroupList">
+              <Field name="homeLocationGroup">
+                <Field name="homeLocation" />
+                <Field name="homeLocationNote" />
+              </Field>
+            </Field>
           </Col>
         </Row>
 

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -71,6 +71,7 @@ const template = (configContext) => {
             </Field>
 
             <Field name="computedCurrentLocation" />
+            <Field name="homeStorageLocation" />
           </Col>
         </Row>
 


### PR DESCRIPTION
**What does this do?**
It adds the `homeLocationGroupList` fields to the templates where `computedCurrentLocation` already exists.

**Why are we doing this? (with JIRA link)**
We need to show the new `homeLocationGroupList` fields beneath the already existing `computedCurrentLocation` field: https://collectionspace.atlassian.net/browse/DRYD-2073

**How should this be tested? Do these changes have associated tests?**
Please follow the steps in the PR: 
https://github.com/collectionspace/cspace-ui.js/pull/355
Instead of starting cspace-ui dev server, start the profile one. First please make sure that the `cspace-ui` dependency in package.json points to your local build: `"cspace-ui": "../cspace-ui.js"`

**Dependencies for merging? Releasing to production?**
The following PRs should be released along: 
https://github.com/collectionspace/application/pull/352
https://github.com/collectionspace/services/pull/541
https://github.com/collectionspace/cspace-ui.js/pull/355
https://github.com/collectionspace/cspace-ui-plugin-profile-fcart.js/pull/33
https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/pull/44
https://github.com/collectionspace/cspace-ui-plugin-profile-materials.js/pull/22
https://github.com/collectionspace/cspace-ui-plugin-profile-publicart.js/pull/35

Please note that the target branch is the new `develop` and not `main`. This is to be able to release patch versions branching `main` and have `develop` for the next minor/major release.

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally