### PR TITLE
DRYD-2127: Procedure > Acquisition > Add Alternate Identifier/Note combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## V8.3.0
+
+### Changes
+
+- Added the Alternative Identifier group of fields (`alternativeIdentifierGroupList/alternativeIdentifierGroup`) to the record editor for Acquisitions.
+
 ## V8.2.0
 
 v8.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -21,6 +21,14 @@ const template = (configContext) => {
         <Cols>
           <Col>
             <Field name="acquisitionReferenceNumber" />
+
+            <Field name="alternativeIdentifierGroupList">
+              <Field name="alternativeIdentifierGroup">
+                <Field name="alternativeIdentifier" />
+                <Field name="alternativeIdentifierNote" />
+              </Field>
+            </Field>
+
             <Field name="accessionDateGroup" />
 
             <InputTable name="acquisitionAuthorizer">


### PR DESCRIPTION
**What does this do?**
Adds a repeating Alternative Identifier group of fields (alternativeIdentifier and alternativeIdentifierNote) to the Acquisition record editor, rendered directly under the Reference number field. The field group mirrors the identically-named group that already exists on the Repatriation Request procedure, using the same labels ("Alternative identifier" / Identifier / Note).

**Why are we doing this? (with JIRA link)**
Kansas needs to record alternate accession numbers (with notes) on acquisition records to support their data migration. https://collectionspace.atlassian.net/browse/DRYD-2127

**How should this be tested? Do these changes have associated tests?**
Please follow the instructions in https://github.com/collectionspace/cspace-ui.js/pull/364

**Dependencies for merging? Releasing to production?**
https://github.com/collectionspace/application/pull/359

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally
