### PR TITLE
DRYD-2125: Procedure > Acquisition > Price Information Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## V8.3.0
+
+### Changes
+
+- On the record editor for Acquisitions, the Price Information fields are now displayed in a collapsible panel, collapsed by default.
+
 ## V8.2.0
 
 v8.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -53,7 +53,7 @@ const template = (configContext) => {
 
             <Field name="transferOfTitleNumber" />
 
-            <Panel name="priceInformation">
+            <Panel name="priceInformation" collapsible collapsed>
               <InputTable name="groupPurchasePrice">
                 <Field name="groupPurchasePriceCurrency" />
                 <Field name="groupPurchasePriceValue" />


### PR DESCRIPTION
**What does this do?**
On the record editor for Acquisitions, the Price Information fields are now displayed in a collapsible panel, collapsed by default.

**Why are we doing this? (with JIRA link)**
To align UI with how other fields exist within the broader application: https://collectionspace.atlassian.net/browse/DRYD-2125

**How should this be tested? Do these changes have associated tests?**
Please follow test instructions in https://github.com/collectionspace/cspace-ui.js/pull/363

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally
